### PR TITLE
ci(build): build project without prisma migration

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -26,5 +26,5 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
       - run: rm -rf node_modules && yarn install --frozen-lockfile
-      - run: yarn build
+      - run: yarn next build
       - run: yarn test:unit


### PR DESCRIPTION
To be able to run the app on platforms like Vercel or Render or deploying with docker, i modified `yarn build` script to run a prisma migration first and then build project, but running the prisma migration in Nodejs Action is not possible , so i replaced build command with pure `next build` to skip migration